### PR TITLE
Rails 7.1 Upgrade

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,6 +12,7 @@ jobs:
           - "2.7"
           - "3.0"
           - "3.1"
+          - "3.2"
 
     name: Ruby ${{ matrix.ruby }} test
     steps:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     cased-ruby (0.8.0)
-      activesupport (>= 6.1, <= 7.1)
+      activesupport (>= 6.1, < 8)
       dotpath (~> 0.1.0)
       faraday (~> 2.0)
       json (~> 2.5.1)
@@ -14,33 +14,42 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.3.1)
+    activesupport (7.1.1)
+      base64
+      bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
+      mutex_m
       tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
+    base64 (0.1.1)
+    bigdecimal (3.1.4)
     byebug (11.1.3)
-    concurrent-ruby (1.1.10)
+    concurrent-ruby (1.2.2)
     connection_pool (2.2.5)
     crack (0.4.5)
       rexml
     docile (1.4.0)
     dotpath (0.1.0)
+    drb (2.1.1)
+      ruby2_keywords
     faraday (2.3.0)
       faraday-net_http (~> 2.0)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (2.0.3)
     hashdiff (1.0.1)
-    i18n (1.12.0)
+    i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     json (2.5.1)
     jwt (2.7.1)
     minitest (5.14.4)
     mocha (1.13.0)
+    mutex_m (0.1.2)
     net-http-persistent (4.0.1)
       connection_pool (~> 2.2)
     parallel (1.20.1)
@@ -93,7 +102,7 @@ GEM
       tty-screen (~> 0.8)
       wisper (~> 2.0)
     tty-screen (0.8.1)
-    tzinfo (2.0.5)
+    tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.0.0)
     webmock (3.14.0)
@@ -102,7 +111,6 @@ GEM
       hashdiff (>= 0.4.0, < 2.0.0)
     wisper (2.0.1)
     yard (0.9.26)
-    zeitwerk (2.6.8)
 
 PLATFORMS
   ruby

--- a/cased-ruby.gemspec
+++ b/cased-ruby.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.7.0'
 
-  spec.add_dependency 'activesupport', '>= 6.1', '< 7.1'
+  spec.add_dependency 'activesupport', '>= 6.1', '<= 7.1'
   spec.add_dependency 'dotpath', '~> 0.1.0'
   spec.add_dependency 'faraday', '~> 2.0'
   spec.add_dependency 'json', '~> 2.5.1'

--- a/cased-ruby.gemspec
+++ b/cased-ruby.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.7.0'
 
-  spec.add_dependency 'activesupport', '>= 6.1', '<= 7.1'
+  spec.add_dependency 'activesupport', '>= 6.1', '< 8'
   spec.add_dependency 'dotpath', '~> 0.1.0'
   spec.add_dependency 'faraday', '~> 2.0'
   spec.add_dependency 'json', '~> 2.5.1'

--- a/gemfile-locks/Gemfile-activesupport-71.lock
+++ b/gemfile-locks/Gemfile-activesupport-71.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     cased-ruby (0.8.0)
-      activesupport (>= 6.1, < 7.1)
+      activesupport (>= 6.1, < 8)
       dotpath (~> 0.1.0)
       faraday (~> 2.0)
       json (~> 2.5.1)
@@ -14,21 +14,30 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.8)
+    activesupport (7.1.1)
+      base64
+      bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
+      mutex_m
       tzinfo (~> 2.0)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
+    base64 (0.1.1)
+    bigdecimal (3.1.4)
     byebug (11.1.3)
     concurrent-ruby (1.2.2)
-    connection_pool (2.2.5)
+    connection_pool (2.4.1)
     crack (0.4.5)
       rexml
     docile (1.4.0)
     dotpath (0.1.0)
+    drb (2.1.1)
+      ruby2_keywords
     faraday (2.3.0)
       faraday-net_http (~> 2.0)
       ruby2_keywords (>= 0.0.4)
@@ -40,6 +49,7 @@ GEM
     jwt (2.7.1)
     minitest (5.14.4)
     mocha (1.13.0)
+    mutex_m (0.1.2)
     net-http-persistent (4.0.1)
       connection_pool (~> 2.2)
     parallel (1.20.1)

--- a/gemfile-locks/Gemfile-activesupport-71.lock
+++ b/gemfile-locks/Gemfile-activesupport-71.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     cased-ruby (0.8.0)
-      activesupport (>= 6.1, <= 7.1)
+      activesupport (>= 6.1, < 7.1)
       dotpath (~> 0.1.0)
       faraday (~> 2.0)
       json (~> 2.5.1)
@@ -14,17 +14,16 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.3.1)
+    activesupport (7.0.8)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
     byebug (11.1.3)
-    concurrent-ruby (1.1.10)
+    concurrent-ruby (1.2.2)
     connection_pool (2.2.5)
     crack (0.4.5)
       rexml
@@ -35,7 +34,7 @@ GEM
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (2.0.3)
     hashdiff (1.0.1)
-    i18n (1.12.0)
+    i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     json (2.5.1)
     jwt (2.7.1)
@@ -93,7 +92,7 @@ GEM
       tty-screen (~> 0.8)
       wisper (~> 2.0)
     tty-screen (0.8.1)
-    tzinfo (2.0.5)
+    tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.0.0)
     webmock (3.14.0)
@@ -102,7 +101,6 @@ GEM
       hashdiff (>= 0.4.0, < 2.0.0)
     wisper (2.0.1)
     yard (0.9.26)
-    zeitwerk (2.6.8)
 
 PLATFORMS
   ruby

--- a/lib/cased.rb
+++ b/lib/cased.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'active_support'
 require 'socket'
 require 'json'
 require 'dotpath'

--- a/lib/cased/cli/interactive_session.rb
+++ b/lib/cased/cli/interactive_session.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'active_support/core_ext/object/blank'
 require 'cased/cli/session'
 require 'tty/prompt'
 

--- a/lib/cased/instrumentation/log_subscriber.rb
+++ b/lib/cased/instrumentation/log_subscriber.rb
@@ -21,7 +21,7 @@ module Cased
         self.class.events += 1
 
         event = JSON.generate(event.payload[:event])
-        name = color('Cased', CYAN, true)
+        name = color('Cased', CYAN, bold: true)
         debug "  #{name} #{event}"
       end
 

--- a/lib/cased/response.rb
+++ b/lib/cased/response.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'active_support/core_ext'
+
 module Cased
   class Response
     attr_reader :body, :exception

--- a/test/lib/cased/instrumentation/log_subscriber_test.rb
+++ b/test/lib/cased/instrumentation/log_subscriber_test.rb
@@ -5,7 +5,7 @@ require 'active_support/testing/assertions'
 module Cased
   module Instrumentation
     class LogSubscriberTest < Cased::Test
-      Event = Struct.new(:payload)
+      Event = Struct.new(:payload, keyword_init: false)
 
       def test_can_log_audit_event
         log_subscriber = Cased::Instrumentation::LogSubscriber.new


### PR DESCRIPTION
Tests were originally failing with the activesupport upgrade. Fixes have been added and CI is green, which is promising